### PR TITLE
Support net6

### DIFF
--- a/WindowsCredentialManager.Tests/WindowsCredentialManager.Tests.csproj
+++ b/WindowsCredentialManager.Tests/WindowsCredentialManager.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/WindowsCredentialManager/Win32/Types/CREDENTIALW.cs
+++ b/WindowsCredentialManager/Win32/Types/CREDENTIALW.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices.ComTypes;
+
 namespace WindowsCredentialManager.Win32.Types
 {
   using System;
@@ -10,7 +12,7 @@ namespace WindowsCredentialManager.Win32.Types
     public CREDENTIAL_TYPE Type;
     [MarshalAs (UnmanagedType.LPWStr)] public string TargetName;
     [MarshalAs (UnmanagedType.LPWStr)] public string? Comment;
-    public DateTimeOffset LastWritten;
+    public FILETIME LastWritten;
     public int BlobSize;
     public SecureBlob? Blob;
     public CREDENTIAL_PERSIST Persist;


### PR DESCRIPTION
When using the library when targeting net6.0 saving a credential will throw an exception:

```
System.TypeLoadException: Cannot marshal field 'LastWritten' of type 'WindowsCredentialManager.Win32.Types.CREDENTIALW': Structures marked with [StructLayout(LayoutKind.Auto)] cannot be marshaled.
   at WindowsCredentialManager.Win32.UnsafeNativeApi.CredWriteW(CREDENTIALW& credential, Int32 flags)
   at WindowsCredentialManager.Credential.Save()
```

This is because the `LastWritten` field on the `CREDENTIALW` type is set to be a `DateTimeOffset` which (in net6.0) has an attribute `LayoutKind.Auto`.

The [`CREDENTIALW`](https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentialw) win32 type defines that field as a `FILETIME` which has a .net equivalent through System.Runtime.Interop (see [here](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.comtypes.filetime?view=net-6.0)) 

Even though the `LastWritten` field is always ignored when writing, Marshaling still fails at this point because of the `StructLayoutKind.Auto` on `DateTimeOffset`.

This PR changes the type of `LastWritten` in the `CREDENTIALW` struct to be a `FILETIME` so that saving a credential works on net6.0.