### PR TITLE
Throw ArgumentException when password is too big

### DIFF
--- a/WindowsCredentialManager.Tests/CredentialTests.cs
+++ b/WindowsCredentialManager.Tests/CredentialTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace WindowsCredentialManager.Tests
 {
   using System.Runtime.InteropServices;
@@ -68,6 +70,22 @@ namespace WindowsCredentialManager.Tests
       var credentialsPromptResult = CredentialsPrompt.ShowWithSaveButton ("a", "b", true);
 
       Assert.That (credentialsPromptResult, Is.Not.Null);
+    }
+
+    [Test]
+    public void ArgumentExceptionThrownWhenSecretIsTooBig()
+    {
+      var genericCredentials = new GenericCredentials ("CRED_TEST");
+
+      genericCredentials.UserName = "my user";
+      genericCredentials.Password = new SecureString();
+
+      for (var i = 0; i < 2561; i++)
+      {
+        genericCredentials.Password.AppendChar('x');
+      }
+
+      Assert.That(() => genericCredentials.Save(), Throws.ArgumentException);
     }
 
     private static string SecureStringToString (SecureString value)

--- a/WindowsCredentialManager.Tests/WindowsCredentialManager.Tests.csproj
+++ b/WindowsCredentialManager.Tests/WindowsCredentialManager.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/WindowsCredentialManager/Credential.cs
+++ b/WindowsCredentialManager/Credential.cs
@@ -12,6 +12,7 @@ namespace WindowsCredentialManager
 
   public abstract class Credential
   {
+    private const int WindowsCredentialManagerMaxSize = 2560;
     public string TargetName { get; }
 
     internal CredentialType Type { get; }
@@ -106,6 +107,11 @@ namespace WindowsCredentialManager
 
         blob = credentialW.Blob;
         credentialW.BlobSize = blob?.Size ?? 0;
+
+        if (credentialW.BlobSize > WindowsCredentialManagerMaxSize)
+        {
+          throw new ArgumentException("Secret is too big for Windows Credential Manager");
+        }
 
         Debug.Assert (credentialW.Type != default, "credentialW.Type != default");
         Debug.Assert (credentialW.TargetName != null, "credentialW.TargetName != null");

--- a/WindowsCredentialManager/Win32/Types/CREDENTIALW.cs
+++ b/WindowsCredentialManager/Win32/Types/CREDENTIALW.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices.ComTypes;
+
 namespace WindowsCredentialManager.Win32.Types
 {
   using System;
@@ -10,7 +12,7 @@ namespace WindowsCredentialManager.Win32.Types
     public CREDENTIAL_TYPE Type;
     [MarshalAs (UnmanagedType.LPWStr)] public string TargetName;
     [MarshalAs (UnmanagedType.LPWStr)] public string? Comment;
-    public DateTimeOffset LastWritten;
+    public FILETIME LastWritten;
     public int BlobSize;
     public SecureBlob? Blob;
     public CREDENTIAL_PERSIST Persist;


### PR DESCRIPTION
Windows Credential Manager only supports credentials up to 2560 bytes (5*512 bytes see `CredentialBlobSize` [here](https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentialw)).

If you exceed this you get a `Win32Exception` with the message `Received bad data from stub`.

This PR will throw an `ArgumentException` when the size exceeds 2560 bytes before it attempts to save.